### PR TITLE
run script should invoke bash

### DIFF
--- a/run
+++ b/run
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 DIRECTORY=`dirname $0`
 


### PR DESCRIPTION
The run script has a shebang invoking /bin/sh, but it tries to source venv/bin/activate, which only works in bash. This would work on a system where /bin/sh is aliased to bash, but that's not the case on my machine, so I've changed the script to require /bin/bash.