### PR TITLE
Change build settings for 'fast' module to link against cairo library

### DIFF
--- a/gum/fast/Makefile
+++ b/gum/fast/Makefile
@@ -7,7 +7,9 @@ fast.so: fast.c
 	gcc -shared -pthread -fPIC -fwrapv -O2 -Wall -fno-strict-aliasing \
             -I/usr/include/python2.5 -I/usr/include/python2.6 \
             -I/usr/include/python2.7 \
-            -lcairo -o fast.so fast.c
+            `pkg-config --cflags cairo` \
+            -o fast.so fast.c \
+            `pkg-config --libs cairo`
 	if [ ! -e ../fast.so ]; then ln -s fast/fast.so ../; fi
 
 fast.c: fast.pyx

--- a/gum/fast/Makefile
+++ b/gum/fast/Makefile
@@ -1,12 +1,17 @@
-all: fast.c
+# Use 'cython2' if present on this system; otherwise fall back to 'cython'.
+CYTHON := $(if $(shell command -v cython2 2>/dev/null), cython2, cython)
 
-fast.c: fast.pyx
-	cython2 fast.pyx
+all: fast.so
+
+fast.so: fast.c
 	gcc -shared -pthread -fPIC -fwrapv -O2 -Wall -fno-strict-aliasing \
             -I/usr/include/python2.5 -I/usr/include/python2.6 \
             -I/usr/include/python2.7 \
             -lcairo -o fast.so fast.c
 	if [ ! -e ../fast.so ]; then ln -s fast/fast.so ../; fi
+
+fast.c: fast.pyx
+	$(CYTHON) fast.pyx
 
 clean:
 	rm -f fast.so fast.c

--- a/gum/fast/fast.h
+++ b/gum/fast/fast.h
@@ -5,11 +5,3 @@ typedef struct {
   void *ctx;
 } PycairoContext;
 
-void cairo_move_to (void *cr, double x, double y);
-void cairo_line_to (void *cr, double x, double y);
-void cairo_rectangle(void *cr, double x, double ymin,
-                     double w, double h);
-void cairo_set_source_rgb (void *cr, double r, double g, double b);
-void cairo_stroke (void *cr);
-void cairo_fill (void *cr);
-void cairo_set_line_width(void *cr, double w);

--- a/gum/fast/fast.pyx
+++ b/gum/fast/fast.pyx
@@ -6,6 +6,8 @@ cdef extern from "math.h":
 cdef extern from "fast.h":
     ctypedef struct PycairoContext:
       void *ctx
+
+cdef extern from "<cairo.h>":
     void cairo_move_to (void *cr, double x, double y) nogil
     void cairo_line_to (void *cr, double x, double y) nogil
     void cairo_rectangle(void *cr, double x, double ymin,

--- a/gum/fx/Makefile
+++ b/gum/fx/Makefile
@@ -1,9 +1,16 @@
-all:
-	cython2 _svf.pyx
+# Use 'cython2' if present on this system; otherwise fall back to 'cython'.
+CYTHON := $(if $(shell command -v cython2 2>/dev/null), cython2, cython)
+
+all: _svf.so
+
+_svf.so: _svf.c
 	gcc -shared -pthread -fPIC -fwrapv -O2 -Wall -fno-strict-aliasing \
             -I/usr/include/python2.5 -I/usr/include/python2.6 \
             -I/usr/include/python2.7 \
             -o _svf.so _svf.c
+
+_svf.c: _svf.pyx
+	$(CYTHON) _svf.pyx
 
 clean:
 	rm -f _svf.so _svf.c


### PR DESCRIPTION
The 'fast' module did not work on my system out of the box, because it could not resolve the external cairo_foo symbols; it compiled, and generated the appropriate extern refs, but did not have a dependency on libcairo.so, and thus the loader would fail to resolve them. I have updated the makefile using pkg-config to generate cflags and linker flags, and now I am able to run the 'fast' module for waveform rendering. This change also allows fast.pyx to make use of libcairo's own header file instead of having to duplicate the definitions in fast.h.

This branch includes the 'cython' vs 'cython2' change, but I'm happy to revise it not to depend on that prior commit, if you'd prefer.