### PR TITLE
Check availability of cython2 and fall back to plain cython if not present

### DIFF
--- a/gum/fast/Makefile
+++ b/gum/fast/Makefile
@@ -1,12 +1,17 @@
-all: fast.c
+# Use 'cython2' if present on this system; otherwise fall back to 'cython'.
+CYTHON := $(if $(shell command -v cython2 2>/dev/null), cython2, cython)
 
-fast.c: fast.pyx
-	cython2 fast.pyx
+all: fast.so
+
+fast.so: fast.c
 	gcc -shared -pthread -fPIC -fwrapv -O2 -Wall -fno-strict-aliasing \
             -I/usr/include/python2.5 -I/usr/include/python2.6 \
             -I/usr/include/python2.7 \
             -lcairo -o fast.so fast.c
 	if [ ! -e ../fast.so ]; then ln -s fast/fast.so ../; fi
+
+fast.c: fast.pyx
+	$(CYTHON) fast.pyx
 
 clean:
 	rm -f fast.so fast.c

--- a/gum/fx/Makefile
+++ b/gum/fx/Makefile
@@ -1,9 +1,16 @@
-all:
-	cython2 _svf.pyx
+# Use 'cython2' if present on this system; otherwise fall back to 'cython'.
+CYTHON := $(if $(shell command -v cython2 2>/dev/null), cython2, cython)
+
+all: _svf.so
+
+_svf.so: _svf.c
 	gcc -shared -pthread -fPIC -fwrapv -O2 -Wall -fno-strict-aliasing \
             -I/usr/include/python2.5 -I/usr/include/python2.6 \
             -I/usr/include/python2.7 \
             -o _svf.so _svf.c
+
+_svf.c: _svf.pyx
+	$(CYTHON) _svf.pyx
 
 clean:
 	rm -f _svf.so _svf.c


### PR DESCRIPTION
It makes sense to invoke cython2 explicitly if it is available, but on my system there is only plain 'cython', so the makefiles do not work. This change adds a check for the existence of 'cython2' and uses 'cython' instead if necessary. It also reorganizes the dependencies so that gcc will be reinvoked if the .so file happens to be deleted for some reason.